### PR TITLE
Update camera.html

### DIFF
--- a/camera.html
+++ b/camera.html
@@ -144,7 +144,7 @@
         async function init() {
             try {
                 // Load COCO-SSD model
-                model = await cocoSsd.load();
+                model = await cocoSsd.load({ base: 'mobilenet_v2' });
                 
                 // Setup camera
                 stream = await navigator.mediaDevices.getUserMedia({ 


### PR DESCRIPTION
By specifying the 'base' parameter with 'mobilenet_v2',  the cocoSsd model uses the mobilenet_V2 architecture as the base feature extractor. If the base is not specified when loading the cocoSsd model, it will default to using the mobilenet_v1 base model, which might be less accurate or slower compared to mobilenet_v2.