### PR TITLE
Updated container alignment of who we are page

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,3 @@
-
-
 :root {
     --primary-color: #0070f3;
     --secondary-color: #000;
@@ -779,7 +777,6 @@ footer {
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
     border-radius: 12px;
     width: 500px; /* Increased width for better spacing */
-    text-align: center;
     animation: fadeIn 0.8s ease-in-out;
 }
 h2 {

--- a/whoweare.html
+++ b/whoweare.html
@@ -29,7 +29,7 @@
 
     <main class="main-content">
         <section class="who-we-are" style="background: rgba(255, 255, 255, 0.7); padding: 25px; padding-bottom: 40px; border-radius: 10px; margin: 20px;">
-            <div class="container">
+            <div class="container" style="width: fit-content; margin: 0 auto;">
                 <h1>Who We Are</h1>
                 <div class="section">
                   <p>


### PR DESCRIPTION
## Description

The alignment of the text container in the Who We Are page was completely left aligned, looking like a mobile view even in desktop view. 

Fixes # (issue)
I fixed the alignment and made the width of the container to fit the space available.

## Type of change
Container alignment 

Please delete options that are not relevant.

- [✔️] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [✔️] My code follows the style guidelines of this project
- [✔️] I have performed a self-review of my own code
- [✔️] I have commented my code, particularly in hard-to-understand areas
- [✔️] I have made corresponding changes to the documentation
- [✔️] My changes generate no new warnings
- [✔️] I have added tests that prove my fix is effective or that my feature works
- [✔️] New and existing unit tests pass locally with my changes
- [✔️] Any dependent changes have been merged and published in downstream modules
